### PR TITLE
Load mobile menu only if necessary

### DIFF
--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -138,9 +138,23 @@
 
   $(document).ready(function() {
     Handlebars.registerPartial("list", $("#ftw-mobile-navigation-list-template").html());
-    $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-navigation-template"]').each(initialize_navigation_button);
+    $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-navigation-template"]:visible').each(initialize_navigation_button);
 
     $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-list-template"]').each(initialize_list_button);
+  });
+
+  window.mobileNavLoaded = false;
+  $(window).resize(function() {
+
+    if (window.mobileNavLoaded) { return; }
+
+    var mobileNavButton = $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-navigation-template"]:visible');
+    var mobileMenuWrapper = $('.mobile-menu.mobile-menu-navigation-mobile-button');
+
+    if (mobileNavButton.length !== 0 && mobileMenuWrapper.length === 0) {
+      window.mobileNavLoaded = true;
+      mobileNavButton.each(initialize_navigation_button);
+    }
   });
 
 })();

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -21,6 +21,7 @@
 
   function close() {
     $('#mobile-menu-wrapper').removeClass("open");
+    $('.ftw-mobile-buttons a').removeClass('selected');
     root.removeClass("menu-open");
   }
 
@@ -133,7 +134,10 @@
     }, link.data('mobile_startup_cachekey'));
   }
 
-  $(document).on("click", "#ftw-mobile-overlay", close);
+  $(document).on("click", "#ftw-mobile-overlay", function(){
+    close();
+    $('.ftw-mobile-buttons a').removeClass('selected');
+  });
 
 
   $(document).ready(function() {

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -21,7 +21,6 @@
 
   function close() {
     $('#mobile-menu-wrapper').removeClass("open");
-    $('.ftw-mobile-buttons a').removeClass('selected');
     root.removeClass("menu-open");
   }
 
@@ -46,7 +45,16 @@
     });
   }
 
+  window.begun_mobile_initialization = false;
   function initialize_navigation_button() {
+    /* This function may be called a lot when resizing, but it should only
+       work the very first time. */
+    if(window.begun_mobile_initialization) {
+      return;
+    } else {
+      window.begun_mobile_initialization = true;
+    }
+
     var link = $(this);
     var current_url = link.parents(".ftw-mobile-buttons").data('currenturl');
 
@@ -147,18 +155,9 @@
     $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-list-template"]').each(initialize_list_button);
   });
 
-  window.mobileNavLoaded = false;
   $(window).resize(function() {
-
-    if (window.mobileNavLoaded) { return; }
-
-    var mobileNavButton = $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-navigation-template"]:visible');
-    var mobileMenuWrapper = $('.mobile-menu.mobile-menu-navigation-mobile-button');
-
-    if (mobileNavButton.length !== 0 && mobileMenuWrapper.length === 0) {
-      window.mobileNavLoaded = true;
-      mobileNavButton.each(initialize_navigation_button);
-    }
+    /* initialize_navigation_button will only work once and then disable itself */
+    $('.ftw-mobile-buttons a[data-mobile_template="ftw-mobile-navigation-template"]:visible').each(initialize_navigation_button);
   });
 
 })();

--- a/ftw/mobile/scss/mobile-buttons.scss
+++ b/ftw/mobile/scss/mobile-buttons.scss
@@ -164,12 +164,21 @@ $color-mobile-button: $color-primary !default;
 .topLevelTabs {
   @include tab-list($color-tab: $color-content-background, $color-tab-select: $color-content-background);
 
+  &:before {
+    visibility: hidden;
+  }
+
   > li > a {
     background-color: $color-secondary;
 
     @include auto-text-color($color-secondary);
   }
 }
+
+.menu-open .topLevelTabs:before {
+  visibility: visible;
+}
+
 
 .mobile-menu.mobile-menu-navigation-mobile-button {
   background-color: $color-secondary;


### PR DESCRIPTION
- Load mobile menu only if the mobile nav button is visible
- Also check for visibility while resizing and load the menu once if necessary
- Fix display issue as I replaced the show/hide behavior for the menus with a toggeling css class
- Remove selected class on all mobile buttons, when a menu gets closed by clicking on the overlay.
