### PR TITLE
Use zindex system from ftw.theming

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use zindex system from ftw.theming to fix dropdown menues
+  [Kevin Bieri]
 
 
 1.0.0a3 (2016-07-11)

--- a/ftw/mobile/scss/mobile-menu.scss
+++ b/ftw/mobile/scss/mobile-menu.scss
@@ -1,7 +1,7 @@
 #ftw-mobile-menu {
+  z-index: $zindex-portal-top + $zindex-header + $zindex-dropdown;
   position: absolute;
   top: 0;
-  z-index: 10;
   width: 100%;
   font-size: $font-size-medium;
   max-width: calc(100% - #{$size-mobile-button});
@@ -43,7 +43,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 999;
+  z-index: $zindex-overlay;
   opacity: .8;
 }
 


### PR DESCRIPTION
Using this system fixes the wrong zindeces on the dropdown menues.

Before:
![bildschirmfoto 2016-07-14 um 17 26 59](https://cloud.githubusercontent.com/assets/1637820/16845178/4d541480-49e8-11e6-8e07-b04bb4195717.png)

After:
![bildschirmfoto 2016-07-14 um 17 27 17](https://cloud.githubusercontent.com/assets/1637820/16845184/50c46de0-49e8-11e6-9dec-768ac9e5eb03.png)
