### PR TITLE
Fix highlighting more than one tab on the top level

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Fix hightlighting more than one top level tab
+  [Kevin]
+
 - Fix issues when the user has no permission to view a parent. [jone]
 
 

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -135,7 +135,7 @@
       var template = Handlebars.compile(templateSource);
       var currentItem = items.nodes[0];
       $(items.toplevel).each(function() {
-        if(currentItem.path.indexOf(this.path) > -1) {
+        if((currentItem.path + "/").indexOf(this.path + "/") > -1) {
           this.cssclass = 'selected';
         }
       });


### PR DESCRIPTION
See https://github.com/4teamwork/winterthur.web/issues/191

Because the code checks if the path contains the current path
it is possible to have more than one top level tab selected.
Fix this by adding a trailing `/`.

E.g.: `themen/` does not contain `themenbereiche/` instead of
      `themen` does contain `themenbereiche`
