### PR TITLE
Fix crash when parent is excluded from navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Fix crash when parent is excluded from navigation by also including
+  parents when excluded from navigation. [jone]
+
 - Make it possible to close the menu when clicking somewhere outside of the menu [Kevin Bieri]
 
 


### PR DESCRIPTION
When the navigation is initialized on a context of which the parent is excluded from navigation, it crashed, because it could not render the "go up" link.

In this situation we show the normally not shown parent since the start point is within this parent. This is consistent with the desktop behavior (e.g. breadcrumbs, navigation portlet).

@mbaechtold wanna take a look?
