### PR TITLE
Mark leaf nodes and remove link to children.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Mark leaf nodes and remove link to children. [jone]
 
 
 1.3.0 (2016-09-20)

--- a/ftw/mobile/navigation.py
+++ b/ftw/mobile/navigation.py
@@ -68,7 +68,7 @@ class MobileNavigation(BrowserView):
         query = self.get_default_query()
         query['path'] = {'query': (list(self.parent_paths_to_nav_root()) +
                                    list(self.get_toplevel_paths())),
-                         'depth': 3}
+                         'depth': 4}
         return query
 
     def get_startup_cachekey(self):

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -155,6 +155,11 @@ $color-mobile-button: $color-primary !default;
   }
 }
 
+.has-no-children a.mobileActionNav.down {
+  display: none;
+}
+
+
 #ftw-mobile-menu {
   > ul {
     @include list-group();

--- a/ftw/mobile/templates/navigation.html.pt
+++ b/ftw/mobile/templates/navigation.html.pt
@@ -39,7 +39,7 @@
 
 <script id="ftw-mobile-navigation-list-template" type="text/x-handlebars-template">
      {{#each nodes}}
-        <li>
+        <li class="node {{#if has_children}}has-children{{else}}has-no-children{{/if}}">
 
             <a href="{{url}}">{{title}}</a>
 

--- a/ftw/mobile/tests/test_navigation.py
+++ b/ftw/mobile/tests/test_navigation.py
@@ -11,18 +11,21 @@ class TestMobileNavigation(FunctionalTestCase):
 
     @browsing
     def test_startup(self, browser):
+        self.maxDiff = None
         self.grant('Manager')
-        create(Builder('folder').titled('five').within(
-            create(Builder('folder').titled('four').within(
-                create(Builder('folder').titled('three').within(
-                    create(Builder('folder').titled('two').within(
-                        create(Builder('folder').titled('one'))))))))))
+        create(Builder('folder').titled('six').within(
+            create(Builder('folder').titled('five').within(
+                create(Builder('folder').titled('four').within(
+                    create(Builder('folder').titled('three').within(
+                        create(Builder('folder').titled('two').within(
+                            create(Builder('folder').titled('one'))))))))))))
 
-        create(Builder('folder').titled('e').within(
-            create(Builder('folder').titled('d').within(
-                create(Builder('folder').titled('c').within(
-                    create(Builder('folder').titled('b').within(
-                        create(Builder('folder').titled('a'))))))))))
+        create(Builder('folder').titled('f').within(
+            create(Builder('folder').titled('e').within(
+                create(Builder('folder').titled('d').within(
+                    create(Builder('folder').titled('c').within(
+                        create(Builder('folder').titled('b').within(
+                            create(Builder('folder').titled('a'))))))))))))
 
         browser.open(view='mobilenav/startup')
         expected_startup_paths = [
@@ -30,10 +33,12 @@ class TestMobileNavigation(FunctionalTestCase):
             u'/plone/a/b',
             u'/plone/a/b/c',
             u'/plone/a/b/c/d',
+            u'/plone/a/b/c/d/e',
             u'/plone/one',
             u'/plone/one/two',
             u'/plone/one/two/three',
             u'/plone/one/two/three/four',
+            u'/plone/one/two/three/four/five',
         ]
         self.assertItemsEqual(
             expected_startup_paths,
@@ -42,7 +47,7 @@ class TestMobileNavigation(FunctionalTestCase):
         browser.open(self.portal.one.two, view='mobilenav/startup')
         self.assertItemsEqual(
             expected_startup_paths + [
-                u'/plone/one/two/three/four/five',
+                u'/plone/one/two/three/four/five/six',
             ],
             map(itemgetter('absolute_path'), browser.json))
 
@@ -53,15 +58,17 @@ class TestMobileNavigation(FunctionalTestCase):
         # has no children it may still have a "children_loaded" property.
         # The responses are expected to contain all children of a node, or none.
         self.assertEquals(
-            {False: [u'/plone/a/b/c',
-                     u'/plone/a/b/c/d',
-                     u'/plone/one/two/three/four',
-                     u'/plone/one/two/three/four/five'],
+            {False: [u'/plone/a/b/c/d',
+                     u'/plone/a/b/c/d/e',
+                     u'/plone/one/two/three/four/five',
+                     u'/plone/one/two/three/four/five/six'],
              True: [u'/plone/a',
                     u'/plone/a/b',
+                    u'/plone/a/b/c',
                     u'/plone/one',
                     u'/plone/one/two',
-                    u'/plone/one/two/three']},
+                    u'/plone/one/two/three',
+                    u'/plone/one/two/three/four']},
 
             {True: map(itemgetter('absolute_path'),
                        filter(lambda item: item.get('children_loaded'),


### PR DESCRIPTION
The idea is to simplify the user interface for leaf nodes:
When navigation in the mobile navigation and reaching a leaf node, it does not make sense to "open" the leaf node in the navigation for seeing its children, since it has none.

In order to be able to tell whether a node as children or is a leaf node we must make sure that we have loaded all its children, when there are any.
This is done by increasing the requested depth by one and later removing the superfluous nodes.

Then a `.has-children` or `.has-no-children` class is set in the `<li>`-node, allowing us to do things such hiding the `.down`-arrow.

This has a downside: increasing the depth by one may have a huge performance impact. When looking into that I also realized that the `getObjPositionInParent`-Index, which is used as sort-index by default, is actually not a real index but loads the real parent for sorting. When sorting large result sets, as it may happen in the mobile navigation, this is very very bad. I think we need to solve this issue and expect that it has a massive positive impact on the performance so that we can account for the negative impact of increasing the depth.
