### PR TITLE
Install ftw.gopip for better performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ eggs/
 parts/
 src/
 var/
+/README.html

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,17 @@ Installation
         ftw.mobile
 
 
+Dependencies
+============
+
+**Warning:**
+This package installs `ftw.gopip <https://github.com/4teamwork/ftw.gopip>`_,
+replacing the ``getObjPositionInParent`` catalog index with a ``FieldIndex``.
+The reason is that ``ftw.mobile`` needs to do large catalog queries sorted by
+``getObjPositionInParent``, which is too slow in standard Plone.
+See the ``ftw.gopip`` readme for further details.
+
+
 Usage
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,8 +2,10 @@ Changelog
 =========
 
 
-1.3.1 (unreleased)
+1.4.0 (unreleased)
 ------------------
+
+- Install ``ftw.gopip`` for better performance. [jone]
 
 - Mark leaf nodes and remove link to children. [jone]
 

--- a/ftw/mobile/profiles/default/metadata.xml
+++ b/ftw/mobile/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
-  <dependencies>
-    <dependency>profile-ftw.theming:default</dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>profile-ftw.theming:default</dependency>
+        <dependency>profile-ftw.gopip:default</dependency>
+    </dependencies>
 </metadata>

--- a/ftw/mobile/upgrades/20160926094153_install_ftw_gopip/upgrade.py
+++ b/ftw/mobile/upgrades/20160926094153_install_ftw_gopip/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallFtwGopip(UpgradeStep):
+    """Install ftw.gopip (reindexes getObjPositionInParent!)
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.setup_install_profile('profile-ftw.gopip:default')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.1.dev0'
+version = '1.4.0.dev0'
 maintainer = 'Mathias Leimgruber'
 
 tests_require = [
@@ -57,6 +57,7 @@ setup(name='ftw.mobile',
           'Plone',
           'Products.CMFCore',
           'Zope2',
+          'ftw.gopip',
           'ftw.theming >= 1.6.0',
           'ftw.upgrade',
           'plone.api',


### PR DESCRIPTION
`ftw.mobile` does large catalog queries ordered by the `getObjPositionInParent`, which is actually very slow because it loads the objects.

`ftw.gopip` improves the `getObjPositionInParent` index read performance by replacing it with a FieldIndex which actually stores the position so that the objects must no longer be woken up for sorting by position.
