### PR TITLE
Prevent inline javascript from evaluating twice

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Prevent inline javascript from evaluating twice.
+  [Kevin Bieri]
 
 
 1.3.0 (2016-09-20)

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -15,7 +15,12 @@
   // with the offcanvas wrapper to make the slide in navigation
   // working on Safari and on iOS devices
   function prepareHTML() {
-    $("body > *").wrapAll(offcanvasWrapper());
+    var scripts = $("body script").detach();
+    $("body").wrapInner(offcanvasWrapper());
+
+    scripts.each(function(script) {
+      $(script).parent().append(script);
+    });
 
     // Prepare initial closed state
     root.addClass("menu-closed");


### PR DESCRIPTION
Closes https://github.com/4teamwork/plonetheme.blueberry/issues/95

The whole document is wrapped in two containers to provide the mobile
navigation functionality. This wrapping forces the browser to evaluate the
inline javascript twice.
So before wrapping the document remove the script tags to stop this behavior.
