### PR TITLE
Leaf nodes: open parent navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Leaf nodes: open parent navigation. [jone]
+
 - Prevent inline javascript from evaluating twice.
   [Kevin Bieri]
 

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -115,7 +115,12 @@
           render_path(toplevel[0].path);
         });
       } else {
-        render_path(current_path);
+        mobileTree.query({path: current_path, depth: 1}, function(toplevel) {
+          if (!toplevel[0].has_children) {
+            current_path = mobileTree.getParentPath(current_path);
+          }
+          render_path(current_path);
+        });
       }
     }
 


### PR DESCRIPTION
When opening the mobile navigation on a node which has no children (leaf node), the navigation should open on the parent as this is more useful since we would not see any children on the leaf node navigation.
