### PR TITLE
Add separate "current node" item in addition to "parent node".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Add separate "current node" item in addition to "parent node". [jone]
+
 - Leaf nodes: open parent navigation. [jone]
 
 - Prevent inline javascript from evaluating twice.

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -4,6 +4,8 @@ $font-size-mobile-button: 2em !default;
 $mobile-menu-height: 54px !default;
 
 $color-mobile-button: $color-primary !default;
+$color-mobile-current: $color-gray-dark !default;
+
 
 @mixin auto-border-color($color: $color-primary) {
   border-color: contrast($color, $color-text-inverted, $color-text, $lightness: 63%);
@@ -138,6 +140,13 @@ $color-mobile-button: $color-primary !default;
       }
       border-bottom: 1px solid $color-gray-dark;
     }
+  }
+
+  .navCurrentNode > a {
+    background-color: $color-mobile-current;
+    @include auto-link-color($color-mobile-current);
+    font-weight: bold;
+    width: 100%;
   }
 }
 

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -6,6 +6,13 @@ $mobile-menu-height: 54px !default;
 $color-mobile-button: $color-primary !default;
 $color-mobile-current: $color-gray-dark !default;
 
+@include declare-variables(
+  size-mobile-button,
+  font-size-mobile-button,
+  mobile-menu-height,
+  color-mobile-button,
+  color-mobile-current);
+
 
 @mixin auto-border-color($color: $color-primary) {
   border-color: contrast($color, $color-text-inverted, $color-text, $lightness: 63%);

--- a/ftw/mobile/templates/navigation.html.pt
+++ b/ftw/mobile/templates/navigation.html.pt
@@ -23,10 +23,14 @@
                           <span i18n:translate="label_goto_parent">Nächst höherer Inhalt {{parentNode.title}} anzeigen.</span>
                       </a>
 
-                      <a href="{{currentNode.url}}">{{currentNode.title}}</a>
+                      <a href="{{parentNode.url}}">{{parentNode.title}}</a>
                   </li>
 
                   {{/if}}
+
+                  <li class="navCurrentNode">
+                      <a href="{{currentNode.url}}">{{currentNode.title}}</a>
+                  </li>
 
                   {{> list}}
                 </ul>


### PR DESCRIPTION
Before, we had a "current node" which also had a link to the parent, which was confusing. Now there are two entries: a parent node and a current node.

The "current node" is the node where the navigation is currently open, not the page which is currently loaded.
## 

| Before | After |
| --- | --- |
| ![bildschirmfoto 2016-10-11 um 13 53 27](https://cloud.githubusercontent.com/assets/7469/19269340/5823fb6a-8fba-11e6-8a16-92b6b9e204ea.png) | ![bildschirmfoto 2016-10-11 um 13 53 52](https://cloud.githubusercontent.com/assets/7469/19269361/78330040-8fba-11e6-944c-1d6a1288d476.png) |

---

I have also declared the theming variables as this was missing..

// @maethu @bierik 
