### PR TITLE
Active-state: Add "navActiveNode" class to the node which is currently loaded.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Add "navActiveNode" class to the node which is currently loaded. [jone]
+
 - Add separate "current node" item in addition to "parent node". [jone]
 
 - Leaf nodes: open parent navigation. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Add separate "current node" item in addition to "parent node". [jone]
+
 - Leaf nodes: open parent navigation. [jone]
 
 - Prevent inline javascript from evaluating twice.

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -101,9 +101,11 @@
 
     var link = $(this);
     var current_url = link.parents("#ftw-mobile-menu-buttons").data('currenturl');
+    var active_path;
 
     function open() {
       var current_path = mobileTree.getPhysicalPath(current_url);
+      active_path = current_path;
       while( current_path && !mobileTree.isLoaded(current_path, 1)) {
         // the current context is not visible in the navigation;
         // lets try the parent
@@ -133,6 +135,7 @@
       mobileTree.queries(
             queries,
             function(items) {
+              $.each(items, function() { mark_active_node(this); });
               render(items);
               // prefetch grand children
               mobileTree.query({path: path, depth: depth + 1});
@@ -161,6 +164,17 @@
       }));
       $('.topLevelTabs').scrollLeft(tabs_scroll_left);
       hideSpinner();
+    }
+
+    function mark_active_node(nodes) {
+      $.each(nodes, function() {
+        if(typeof(this.active) !== 'undefined') {
+          // Already processed.
+          return;
+        }
+        this.active = active_path == this.path;
+        mark_active_node(this.nodes);
+      });
     }
 
     function showSpinner() {

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -4,6 +4,8 @@ $font-size-mobile-button: 2em !default;
 $mobile-menu-height: 54px !default;
 
 $color-mobile-button: $color-primary !default;
+$color-mobile-current: $color-gray-dark !default;
+
 
 @mixin auto-border-color($color: $color-primary) {
   border-color: contrast($color, $color-text-inverted, $color-text, $lightness: 63%);
@@ -138,6 +140,13 @@ $color-mobile-button: $color-primary !default;
       }
       border-bottom: 1px solid $color-gray-dark;
     }
+  }
+
+  .navCurrentNode > a {
+    background-color: $color-mobile-current;
+    @include auto-link-color($color-mobile-current);
+    font-weight: bold;
+    width: 100%;
   }
 }
 

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -6,6 +6,13 @@ $mobile-menu-height: 54px !default;
 $color-mobile-button: $color-primary !default;
 $color-mobile-current: $color-gray-dark !default;
 
+@include declare-variables(
+  size-mobile-button,
+  font-size-mobile-button,
+  mobile-menu-height,
+  color-mobile-button,
+  color-mobile-current);
+
 
 @mixin auto-border-color($color: $color-primary) {
   border-color: contrast($color, $color-text-inverted, $color-text, $lightness: 63%);

--- a/ftw/mobile/templates/navigation.html.pt
+++ b/ftw/mobile/templates/navigation.html.pt
@@ -23,10 +23,14 @@
                           <span i18n:translate="label_goto_parent">Nächst höherer Inhalt {{parentNode.title}} anzeigen.</span>
                       </a>
 
-                      <a href="{{currentNode.url}}">{{currentNode.title}}</a>
+                      <a href="{{parentNode.url}}">{{parentNode.title}}</a>
                   </li>
 
                   {{/if}}
+
+                  <li class="navCurrentNode">
+                      <a href="{{currentNode.url}}">{{currentNode.title}}</a>
+                  </li>
 
                   {{> list}}
                 </ul>

--- a/ftw/mobile/templates/navigation.html.pt
+++ b/ftw/mobile/templates/navigation.html.pt
@@ -18,7 +18,7 @@
                 <ul>
                   {{#if parentNode}}
 
-                  <li class="navParentNode">
+                  <li class="navParentNode {{#if parentNode.active}}navActiveNode{{/if}}">
                       <a href="{{parentNode.url}}" class="mobileActionNav up">
                           <span i18n:translate="label_goto_parent">Nächst höherer Inhalt {{parentNode.title}} anzeigen.</span>
                       </a>
@@ -28,7 +28,7 @@
 
                   {{/if}}
 
-                  <li class="navCurrentNode">
+                  <li class="navCurrentNode {{#if currentNode.active}}navActiveNode{{/if}}">
                       <a href="{{currentNode.url}}">{{currentNode.title}}</a>
                   </li>
 
@@ -43,7 +43,7 @@
 
 <script id="ftw-mobile-navigation-list-template" type="text/x-handlebars-template">
      {{#each nodes}}
-        <li class="node {{#if has_children}}has-children{{else}}has-no-children{{/if}}">
+        <li class="node {{#if has_children}}has-children{{else}}has-no-children{{/if}} {{#if active}}navActiveNode{{/if}}">
 
             <a href="{{url}}">{{title}}</a>
 


### PR DESCRIPTION
Add a class `navActiveNode` to the `<li>` of nodes which represent the currently loaded page. No standard CSS is applied.

🚧 Based on #31 because of markup changes.
