### PR TITLE
hide current item on navigation root.

### DIFF
--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -154,6 +154,8 @@
         }
       });
 
+      currentItem.visible = currentItem.path != currentItem.id;
+
       var tabs_scroll_left = $('.topLevelTabs').scrollLeft();
       $('#ftw-mobile-menu').html(template({
         toplevel: items.toplevel,

--- a/ftw/mobile/templates/navigation.html.pt
+++ b/ftw/mobile/templates/navigation.html.pt
@@ -28,9 +28,11 @@
 
                   {{/if}}
 
+                  {{#if currentNode.visible }}
                   <li class="navCurrentNode {{#if currentNode.active}}navActiveNode{{/if}}">
                       <a href="{{currentNode.url}}">{{currentNode.title}}</a>
                   </li>
+                  {{/if}}
 
                   {{> list}}
                 </ul>


### PR DESCRIPTION
When clicking on a navigation tab, the current item should not be shown since it is the navigation tab.

Fixes #33

| Before | After |
| --- | --- |
| ![bildschirmfoto 2016-10-11 um 17 55 38](https://cloud.githubusercontent.com/assets/7469/19278004/038c8f28-8fdc-11e6-9246-c0c692ea7126.png) | ![bildschirmfoto 2016-10-11 um 17 56 07](https://cloud.githubusercontent.com/assets/7469/19278011/095b1a28-8fdc-11e6-96fa-356f49c9d4d2.png) |
