### PR TITLE
Make tabs and levels on root configurable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Mobile buttons: add settings "show_tabs" and "show_two_levels_on_root". [jone]
+
 - Pass the url of the navigation root to the handlebars template.
   [mbaechtold]
 

--- a/ftw/mobile/buttons.py
+++ b/ftw/mobile/buttons.py
@@ -13,6 +13,7 @@ LINK_TEMPLATE = '''
    data-mobile_endpoint="{endpoint}"
    data-mobile_startup_cachekey="{startup_cachekey}"
    data-mobile_template="{mobile_template}"
+   data-mobile_settings='{settings}'
    data-mobile_data='{data}'
    data-mobile_label='{label}'>
     {label}
@@ -54,11 +55,15 @@ class BaseButton(object):
     def startup_cachekey(self):
         return ''
 
+    def settings(self):
+        return {}
+
     def render_button(self):
         return LINK_TEMPLATE.format(url='#',
                                     startup_cachekey=self.startup_cachekey(),
                                     mobile_template=self.data_template(),
                                     data=json.dumps(self.data()),
+                                    settings=json.dumps(self.settings()),
                                     label=self.label(),
                                     endpoint=self.endpoint())
 
@@ -102,3 +107,7 @@ class NavigationButton(BaseButton):
     def startup_cachekey(self):
         return (self.context.restrictedTraverse('@@mobilenav')
                 .get_startup_cachekey())
+
+    def settings(self):
+        return {'show_tabs': True,
+                'show_two_levels_on_root': True}

--- a/ftw/mobile/js/navigation-button.js
+++ b/ftw/mobile/js/navigation-button.js
@@ -38,7 +38,7 @@
       // );
       function query(q, success, onRequest) {
         q['path'] = q['path'].replace(/^\//, '');
-        load(q['path'], q['depth'],
+        load(q['path'], q['depth'], (q['exclude_root'] || false),
              function(items) {
                if (typeof success === 'function') {
                  success(items);
@@ -121,7 +121,7 @@
         }
       }
 
-      function load(path, depth, callback, onRequest) {
+      function load(path, depth, exclude_root, callback, onRequest) {
         /** We will need to know whether there are children for each
             requested node.
             In order to do that, we need to make sure that we have loaded one
@@ -129,7 +129,7 @@
         **/
         var queryDepth = depth;
         var requestDepth = depth + 1;
-        var success = function() { callback(treeify(queryResults(path, requestDepth),
+        var success = function() { callback(treeify(queryResults(path, requestDepth, exclude_root),
                                              path, queryDepth)); };
         if (isLoaded(path, requestDepth)) {
           success();
@@ -188,14 +188,16 @@
         });
       }
 
-      function queryResults(path, depth) {
+      function queryResults(path, depth, exclude_root) {
         if (depth < 1) {
           throw 'mobileTree.queryResults: Unsupported depth < 1';
         }
 
         var results = [];
-        if (path in storage.node_by_path) {
-          results.push(storage.node_by_path[path]);
+        if(!exclude_root) {
+          if (path in storage.node_by_path) {
+            results.push(storage.node_by_path[path]);
+          }
         }
 
         if (depth === 1) {

--- a/ftw/mobile/js/navigation-button.js
+++ b/ftw/mobile/js/navigation-button.js
@@ -11,7 +11,10 @@
 
       function init(current_url, endpoint_viewname, ready_callback, startup_cachekey){
         root_url = $("#ftw-mobile-menu-buttons").data("navrooturl");
-        var root_node = {url: root_url};
+        var root_node = {
+          url: root_url,
+          path: ''
+        };
         storage = {node_by_path: {'': root_node},
                    nodes_by_parent_path: {}};
         endpoint = endpoint_viewname;
@@ -165,10 +168,10 @@
           var parentPath = getParentPath(this.path);
 
           if(isPathInQueryOrParent(this.path, queryPath, queryDepth)) {
-            if(!(parentPath in by_path)) {
-              tree.push(this);
-            } else {
+            if(parentPath in by_path && parentPath !== this.path) {
               by_path[parentPath].nodes.push(this);
+            } else {
+              tree.push(this);
             }
           }
 
@@ -191,7 +194,7 @@
         }
 
         var results = [];
-        if (path && path in storage.node_by_path) {
+        if (path in storage.node_by_path) {
           results.push(storage.node_by_path[path]);
         }
 

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -138,6 +138,13 @@
         depth = 3;
       }
 
+      var classes = [];
+      if (depth === 2) {
+        classes.push('mobile-layout-one-level');
+      } else if (depth === 3) {
+        classes.push('mobile-layout-two-levels');
+      }
+
       var show_parent = true;
       if (path === '') {
         show_parent = false;
@@ -154,14 +161,14 @@
             queries,
             function(items) {
               $.each(items, function() { mark_active_node(this); });
-              render(items);
+              render(items, classes);
               // prefetch grand children
               mobileTree.query({path: path, depth: depth + 1});
             },
             showSpinner);
     }
 
-    function render(items) {
+    function render(items, classes) {
       var templateName = link.data('mobile_template');
       var templateSource = $('#' + templateName).html();
       var template = Handlebars.compile(templateSource);
@@ -182,6 +189,7 @@
         nodes: currentItem.nodes,
         parentNode: items.parent ? items.parent[0] : null,
         name: link.parent().attr('id'),
+        classes: classes.join(' '),
         settings: settings
       }));
       $('.topLevelTabs').scrollLeft(tabs_scroll_left);

--- a/ftw/mobile/templates/navigation.html
+++ b/ftw/mobile/templates/navigation.html
@@ -15,7 +15,7 @@
 
         <div class="tabPanes">
             <div class="tabPane">
-                <ul>
+                <ul class="{{classes}}">
                   {{#if parentNode}}
 
                   <li class="navParentNode {{#if parentNode.active}}navActiveNode{{/if}}">

--- a/ftw/mobile/templates/navigation.html
+++ b/ftw/mobile/templates/navigation.html
@@ -2,6 +2,7 @@
 
     <div class="mobile-menu mobile-menu-{{name}}">
 
+        {{#if settings.show_tabs}}
         <ul class="topLevelTabs">
             {{#each toplevel}}
 
@@ -10,6 +11,7 @@
              {{/each}}
 
         </ul>
+        {{/if}}
 
         <div class="tabPanes">
             <div class="tabPane">


### PR DESCRIPTION
The mobile button adapter now has a `settings` method, which can be customized, and returns these default settings:

``` python
    def settings(self):
        return {'show_tabs': True,
                'show_two_levels_on_root': True}
```

In order to make that possible I had to refactor the mobileTree querying:
- navigation roots are no longer excluded from the result set
- the new option `exclude_root` in the query object allows to remove the root node when doing recursive queries

@maethu 
/cc @bierik 
