### PR TITLE
Pass the url of the navigation root to the handlebars template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Pass the url of the navigation root to the handlebars template.
+  [mbaechtold]
+
 - Use helper text for screenreaders also as title attribute on the link itself.
   [mathias.leimgruber]
 

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -158,6 +158,7 @@
 
       var tabs_scroll_left = $('.topLevelTabs').scrollLeft();
       $('#ftw-mobile-menu').html(template({
+        navRootUrl: $("#ftw-mobile-menu-buttons").data('navrooturl'),
         toplevel: items.toplevel,
         currentNode: currentItem,
         nodes: currentItem.nodes,


### PR DESCRIPTION
This is useful if you need to render a link to the navigation root in the mobile navigation.
