### PR TITLE
Fix invalid markup in template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix invalid markup in template, causing broken markup with chameleon. [jone]
 
 
 1.5.0 (2016-10-17)

--- a/ftw/mobile/templates/buttons_viewlet.pt
+++ b/ftw/mobile/templates/buttons_viewlet.pt
@@ -10,7 +10,7 @@
         </ul>
     </nav>
     <div id="ftw-mobile-menu"></div>
-    <div id="ftw-mobile-menu-overlay">
+    <div id="ftw-mobile-menu-overlay"></div>
 </div>
 
 <tal:HANDLEBARS_LIST_TEMPLATE replace="structure view/handlebars_list_html" />


### PR DESCRIPTION
The missing closeing tag was automatically "fixed" by zope.pagetemplate but not by chameleon, causing wrong nesting and a broken page.

/cc @bierik 
