### PR TITLE
Hide current path on root when showing one level.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Hide current path on root when showing one level. [jone]
+
 - Fix invalid markup in template, causing broken markup with chameleon. [jone]
 
 

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -179,7 +179,11 @@
         }
       });
 
-      currentItem.visible = currentItem.path != currentItem.id;
+      if (settings.show_two_levels_on_root) {
+        currentItem.visible = currentItem.path != currentItem.id;
+      } else {
+        currentItem.visible = currentItem.path !== '';
+      }
 
       var tabs_scroll_left = $('.topLevelTabs').scrollLeft();
       $('#ftw-mobile-menu').html(template({


### PR DESCRIPTION
When using the one-level-layout on root, the "current node" should not be displayed, but it should be displayed when on the first level.
