### PR TITLE
Toggle aria-hidden state on mobile navigation elements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Toggle aria-hidden attribute on mobile navigation elements
+  [raphael-s]
 
 
 1.6.0 (2016-11-07)

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -27,14 +27,18 @@
   }
 
   function openMenu() {
-    $('#ftw-mobile-menu').addClass("open");
-    $('#ftw-mobile-menu').trigger('mobilenav:menu:opened');
+    var mobileMenu = $('#ftw-mobile-menu');
+    mobileMenu.addClass("open");
+    mobileMenu.attr('aria-hidden', 'false');
+    mobileMenu.trigger('mobilenav:menu:opened');
   }
 
   function closeMenu() {
     closeLinks();
-    $('#ftw-mobile-menu').removeClass("open");
-    $('#ftw-mobile-menu').trigger('mobilenav:menu:closed');
+    var mobileMenu = $('#ftw-mobile-menu');
+    mobileMenu.removeClass("open");
+    mobileMenu.attr('aria-hidden', 'true');
+    mobileMenu.trigger('mobilenav:menu:closed');
   }
 
   function slideOut() {
@@ -43,6 +47,7 @@
       root.removeClass("menu-opened");
       root.addClass("menu-closed");
       root.off(vendorTransitionEnd.join(" "));
+      $('#ftw-mobile-menu').attr('aria-hidden', 'true');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:closed');
     });
   }
@@ -53,6 +58,7 @@
       root.addClass("menu-opened");
       root.removeClass("menu-closed");
       root.off(vendorTransitionEnd.join(" "));
+      $('#ftw-mobile-menu').attr('aria-hidden', 'false');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:opened');
     });
   }

--- a/ftw/mobile/templates/buttons_viewlet.pt
+++ b/ftw/mobile/templates/buttons_viewlet.pt
@@ -9,7 +9,7 @@
             </li>
         </ul>
     </nav>
-    <div id="ftw-mobile-menu"></div>
+    <div id="ftw-mobile-menu" aria-hidden="true"></div>
     <div id="ftw-mobile-menu-overlay"></div>
 </div>
 


### PR DESCRIPTION
Adds js functionality to toggle aria attributes (`aria-hidden`) on mobile navigation elements.

