### PR TITLE
Actually mark external links with a "external-link" class in navtree

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Actually mark external links with a "external-link" class in navtree.
+  [mathias.leimgruber]
 
 
 1.6.1 (2016-11-08)

--- a/ftw/mobile/templates/navigation.html
+++ b/ftw/mobile/templates/navigation.html
@@ -48,7 +48,7 @@
      {{#each nodes}}
         <li class="node {{#if has_children}}has-children{{else}}has-no-children{{/if}} {{#if active}}navActiveNode{{/if}}">
 
-            <a href="{{url}}">{{title}}</a>
+            <a href="{{url}}"{{#if externallink}} class="external-link"{{/if}}>{{title}}</a>
 
             <a href="{{url}}" class="mobileActionNav down"
                title="{{i18n "label_goto_children"}} {{title}}">


### PR DESCRIPTION
This feature was already implemented, but we missed somehow to actually use the externallink attribute 😄 
