### PR TITLE
Close mobile navigation on resize to desktop site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Close the mobile-navigation when the screen size changes from mobile
+  to desktop while the navigation is open.
+  [raphael-s]
 
 
 1.6.2 (2016-11-09)

--- a/ftw/mobile/scss/mobile-menu.scss
+++ b/ftw/mobile/scss/mobile-menu.scss
@@ -64,6 +64,9 @@ html.menu-open {
 
   #offcanvas-content {
     @include transform(translate(100%) translate(-$size-mobile-button));
+    @include screen-large() {
+      @include transform(none);
+    }
   }
 
   #ftw-mobile-menu {


### PR DESCRIPTION
Fixes an edge case where the site is resized to desktop sized while the mobile navigation is open. This would lead to the page removing the mobile navigation but not sliding the page back in:
<img width="1440" alt="screen shot 2016-11-14 at 14 56 51" src="https://cloud.githubusercontent.com/assets/16755391/20267379/bb404cd2-aa7a-11e6-82c3-30af78d84e00.png">

This is now checked on every resize of the page and if the mobile navigation suddenly disappears it will slide the content back in.
