### PR TITLE
Do not detach script tags of type x-handlebars-template. jQuery is not able to re-attach them.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not detach script tags of type x-handlebars-template. jQuery is not able to re-attach them.
+  [mathias.leimgruber]
 
 
 1.6.3 (2016-11-25)

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -15,9 +15,8 @@
   // with the offcanvas wrapper to make the slide in navigation
   // working on Safari and on iOS devices
   function prepareHTML() {
-    var scripts = $("body script").detach();
+    var scripts = $("body script").not("[type='text/x-handlebars-template']").detach();
     $("body").wrapInner(offcanvasWrapper());
-
     scripts.each(function(script) {
       $(script).parent().append(script);
     });


### PR DESCRIPTION
I'm not really able to explain this...

But IMHO the handlebars template does not trigger any events, so it's not necessary to detach and reattach them anyway. 