### PR TITLE
BugFix: 'children_loaded' flag was not set on prepended items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Append current context path to `prepend_unauthorized_parents`, because the current obj may
+  be excluded from nav.
+  [mathias.leimgruber]
 
 
 1.6.4 (2016-12-01)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
+- Set the `children_loaded` flag on prepended nodes too.
+  [mathias.leimgruber]
+
 - Append current context path to `prepend_unauthorized_parents`, because the current obj may
   be excluded from nav.
   [mathias.leimgruber]

--- a/ftw/mobile/navigation.py
+++ b/ftw/mobile/navigation.py
@@ -121,8 +121,15 @@ class MobileNavigation(BrowserView):
         """
 
         nodes_paths = map(itemgetter('absolute_path'), nodes)
+        paths_to_check = list(self.parent_paths_to_nav_root())
+
+        # Append current context path also, because the current obj may
+        # be excluded from nav.
+        paths_to_check.append('/'.join(self.context.getPhysicalPath()))
+
         missing_paths = filter(lambda path: path not in nodes_paths,
-                               self.parent_paths_to_nav_root())
+                               paths_to_check)
+
         if not missing_paths:
             return nodes
 

--- a/ftw/mobile/navigation.py
+++ b/ftw/mobile/navigation.py
@@ -60,8 +60,11 @@ class MobileNavigation(BrowserView):
             response.setHeader('Cache-Control',
                                '{}, max-age=31536000'.format(visibility))
 
-        nodes = self.get_nodes_by_query(self.get_startup_query())
+        query = self.get_startup_query()
+        nodes = self.get_nodes_by_query(query)
         nodes = self.prepend_unauthorized_parents(nodes)
+        map(partial(self.set_children_loaded_flag, query), nodes)
+
         return json.dumps(nodes)
 
     def get_startup_query(self):
@@ -152,7 +155,6 @@ class MobileNavigation(BrowserView):
                         query,
                         unrestricted_search=unrestricted_search,
                         filter_exclude_from_nav=filter_exclude_from_nav))
-        map(partial(self.set_children_loaded_flag, query), nodes)
         return nodes
 
     def get_brains(self, query, unrestricted_search=False,

--- a/ftw/mobile/tests/test_navigation.py
+++ b/ftw/mobile/tests/test_navigation.py
@@ -236,3 +236,17 @@ class TestMobileNavigation(FunctionalTestCase):
         self.assertItemsEqual(
             [u'/plone/container/visible-child'],
             map(itemgetter('absolute_path'), browser.json))
+
+    @browsing
+    def test_children_loaded_flag_on_prepended_items(self, browser):
+        self.grant('Manager')
+        create(Builder('folder').titled('1b').within(
+            create(Builder('folder').titled('1a')
+                                    .having(excludeFromNav=True))))
+        create(Builder('folder').titled('2a'))
+
+        browser.open(self.portal.get('1a').get('1b'), view='mobilenav/startup')
+
+        # 1a was prepended, since it was excluded from nav.
+        response = browser.json
+        self.assertIn('children_loaded', response[0])


### PR DESCRIPTION
This is need in order the JS knows if there are more items to load or not.

The fix is separated into two parts:
1. Add the current content to the prepended items, since it may not be there.
2. Set the 'children_loaded' also on  prepended items.

The test covers both issues. 