### PR TITLE
Fix mobile menu transition on IE>=9

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix mobile menu transition on IE>=9.
+  [Kevin Bieri]
 
 
 1.6.5 (2017-01-18)

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -8,7 +8,7 @@
 
   var vendorTransitionEnd = [
     "webkitTransitionEnd",
-    "transitionEnd"
+    "transitionend"
   ];
 
   // Here we need to wrap the whole content in the body


### PR DESCRIPTION
IE>=9 only listens on `transionend` not `transionEnd` event.
https://msdn.microsoft.com/en-us/library/dn632682(v=vs.85).aspx