### PR TITLE
Improve accessibility

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,12 @@ Changelog
 1.6.7 (unreleased)
 ------------------
 
-- Introduce swipe gesture for closing the mobile menu.
-  [Kevin Bieri]
+- Set focus on active element on the tab navs [Kevin Bieri]
+- Make possible to close the navigation using Escape key [Kevin Bieri]
+- Skip links in the mobile menu when it's closed [Kevin Bieri]
+- Fix icon size for IE11 in mobile navigation [Kevin Bieri]
+- Fix offset of overlay in IE11 and Edge [Kevin Bieri]
+- Introduce swipe gesture for closing the mobile menu. [Kevin Bieri]
 
 
 1.6.6 (2017-02-16)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.6.7 (unreleased)
 ------------------
 
+- Fix: ftw.testbrowser compatibility. [mathias.leimgruber]
 - Set focus on active element on the tab navs [Kevin Bieri]
 - Make possible to close the navigation using Escape key [Kevin Bieri]
 - Skip links in the mobile menu when it's closed [Kevin Bieri]

--- a/ftw/mobile/js/simple-buttons.js
+++ b/ftw/mobile/js/simple-buttons.js
@@ -40,7 +40,7 @@
     mobileMenu.trigger('mobilenav:menu:closed');
   }
 
-  function slideOut() {
+  function slideOut(link) {
     root.removeClass("menu-open");
     root.on(vendorTransitionEnd.join(" "), function() {
       root.removeClass("menu-opened");
@@ -48,6 +48,10 @@
       root.off(vendorTransitionEnd.join(" "));
       $('#ftw-mobile-menu').attr('aria-hidden', 'true');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:closed');
+      // !!! This implementation of focusing the button is a workaround !!!
+      // The implementation will not work if the button is being renamed.
+      // The origin of the click event should be passed by the caller
+      $("#navigation-mobile-button > a").focus();
     });
   }
 
@@ -59,6 +63,7 @@
       root.off(vendorTransitionEnd.join(" "));
       $('#ftw-mobile-menu').attr('aria-hidden', 'false');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:opened');
+      $('.topLevelTabs > li > a').first().focus();
     });
   }
 
@@ -241,7 +246,7 @@
         event.preventDefault();
         open();
         closeMenu();
-        toggleNavigation();
+        toggleNavigation(link);
       });
 
       $(document).on('click', '.topLevelTabs a', function(event) {
@@ -259,6 +264,7 @@
               event.preventDefault();
               render_path(path);
             }
+            $('.topLevelTabs > li.selected > a').first().focus();
           },
           showSpinner);
       });
@@ -276,6 +282,11 @@
     slideOut();
   })
   .on("click", closeMenu)
+  .on("keyup", function(event) {
+    if(event.which === $.ui.keyCode.ESCAPE) {
+      slideOut();
+    }
+  })
   .ready(function() {
     Handlebars.registerPartial("list", $("#ftw-mobile-navigation-list-template").html());
 

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -1,5 +1,5 @@
 $size-mobile-button: 72px !default;
-$font-size-mobile-button: 2em !default;
+$font-size-mobile-button: $font-size-base * 2 !default;
 
 $mobile-menu-height: 54px !default;
 
@@ -36,6 +36,7 @@ $color-mobile-current: $color-gray-dark !default;
         overflow: hidden;
         white-space: nowrap;
         width: $size-mobile-button;
+        font-size: $font-size-mobile-button / 2;
 
         &:before {
           @include auto-text-color($color-mobile-button);
@@ -43,7 +44,6 @@ $color-mobile-current: $color-gray-dark !default;
           background-color: $color-mobile-button;
           width: $size-mobile-button;
           line-height: $size-mobile-button;
-          font-size: $font-size-mobile-button;
         }
       }
     }

--- a/ftw/mobile/scss/mobile-menu.scss
+++ b/ftw/mobile/scss/mobile-menu.scss
@@ -1,11 +1,12 @@
 #ftw-mobile-menu {
   @include translate(-100%);
-  z-index: $zindex-portal-top + $zindex-header + $zindex-dropdown;
+  z-index: $zindex-overlay + 1;
   position: absolute;
   top: 0;
   width: 100%;
   font-size: $font-size-medium;
   max-width: calc(100% - #{$size-mobile-button});
+  background-color: $color-content-background;
 
   &.open {
     @include translate();
@@ -49,10 +50,6 @@
   transition: opacity .2s linear;
   pointer-events: none;
   will-change: opacity;
-}
-
-@include ie-only("#ftw-mobile-menu-overlay") {
-  left: calc(100% - #{$size-mobile-button});
 }
 
 html.menu-open {

--- a/ftw/mobile/scss/mobile-menu.scss
+++ b/ftw/mobile/scss/mobile-menu.scss
@@ -59,6 +59,16 @@ html.menu-open {
   overflow: hidden;
 }
 
+.menu-closed {
+  #ftw-mobile-menu {
+    display: none;
+
+    &.open {
+      display: block;
+    }
+  }
+}
+
 .menu-open {
 
   body {
@@ -76,6 +86,7 @@ html.menu-open {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     height: 100vh;
+    display: block;
   }
 
   #ftw-mobile-menu-overlay {

--- a/ftw/mobile/tests/test_navigation.py
+++ b/ftw/mobile/tests/test_navigation.py
@@ -162,7 +162,7 @@ class TestMobileNavigation(FunctionalTestCase):
         john = create(Builder('user').named('John', 'Doe'))
 
         browser.login(john)
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.open(folder, view='mobilenav/startup')
 
     @browsing

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ maintainer = 'Mathias Leimgruber'
 tests_require = [
     'Products.CMFPlone',
     'ftw.builder',
-    'ftw.testbrowser',
+    'ftw.testbrowser>=1.23.0',
     'ftw.testing',
     'transaction',
     'plone.app.multilingual',


### PR DESCRIPTION
Closes https://github.com/4teamwork/bern.web/issues/1215

- Set focus on active element on the tab navs
- Make possible to close the navigation using Escape key
- Skip links in the mobile menu when it's closed

## IE fixes
- Fix icon size for IE11 in mobile navigation
- Fix offset of overlay in IE11 and Edge