### PR TITLE
Display static title in navigation for plone site root.

### DIFF
--- a/ftw/mobile/templates/navigation.html
+++ b/ftw/mobile/templates/navigation.html
@@ -23,8 +23,11 @@
                          title="{{i18n "label_goto_parent"}} {{parentNode.title}}">
                           <span>{{i18n "label_goto_parent"}} {{parentNode.title}}</span>
                       </a>
-
-                      <a href="{{parentNode.url}}">{{parentNode.title}}</a>
+                      {{#if parentNode.title}}
+                        <a href="{{parentNode.url}}">{{parentNode.title}}</a>
+                      {{else}}
+                        <a href="{{parentNode.url}}">Startseite</a>
+                      {{/if}}
                   </li>
 
                   {{/if}}

--- a/ftw/mobile/tests/test_navigation.py
+++ b/ftw/mobile/tests/test_navigation.py
@@ -155,6 +155,7 @@ class TestMobileNavigation(FunctionalTestCase):
         Plone principal but it should not be possible to misuse the endpoint
         for getting those informations on _any_ content.
         """
+        browser.exception_bubbling = True
         self.grant('Manager')
         wftool = getToolByName(self.portal, 'portal_workflow')
         wftool.setChainForPortalTypes(['Folder'], 'simple_publication_workflow')


### PR DESCRIPTION
The plone siteroot is not included in the tree query response so
the parent link to the plone site root has no label. Thus display a static
label.