### PR TITLE
Fix getting children if the root is not the portal_root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
+- Fix getting children if the root is not the portal_root. [mathias.leimgruber]
+
 - Make compatible with ftw.theming 2.0.0. [Kevin Bieri]
 
 

--- a/ftw/mobile/resources/js/navigation-button.js
+++ b/ftw/mobile/resources/js/navigation-button.js
@@ -137,7 +137,7 @@
           if (typeof onRequest === 'function') {
             onRequest();
           }
-          $.get(portal_url + '/' + path + '/' + endpoint + '/children',
+          $.get(root_url + '/' + path + '/' + endpoint + '/children',
                 {'depth:int': requestDepth},
                 function(data) {
                   data.map(storeNode);


### PR DESCRIPTION
Structure:
- de
  - item1
    - item1.1
  - item2
- fr
  - otheritem

If the nav root is `/de`, getting the children only worked because of acquisition. 
We used the portal_url instead of the root_url. 

The request made to the backend was for example `/item/item1/item1.1/@@mobielnav/children`.

Obviously this does not always works. 
Using the `root_url` which was already there solves the problem. 
