### PR TITLE
Extend settings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.8.1 (unreleased)
+1.9.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow opening top level tabs directly. [Kevin Bieri]
+- Allow showing leafnote siblings. [Kevin Bieri]
 
 
 1.8.0 (2018-03-19)

--- a/ftw/mobile/resources/js/simple-buttons.js
+++ b/ftw/mobile/resources/js/simple-buttons.js
@@ -196,7 +196,7 @@
         }
       } else {
         mobileTree.query({path: current_path, depth: 1}, function(toplevel) {
-          if (!toplevel[0].has_children) {
+          if (settings.show_leaf_node_siblings && !toplevel[0].has_children) {
             current_path = mobileTree.getParentPath(current_path);
           }
           render_path(current_path);
@@ -304,6 +304,7 @@
       });
 
       $(document).on('click', '.topLevelTabs a', function(event) {
+        if (settings.open_top_level_tabs) { return; }
         var path = mobileTree.getPhysicalPath($(this).attr('href'));
         mobileTree.query(
           {path: path, depth: 2},


### PR DESCRIPTION
- Allow opening top level tabs directly.
- Allow showing leafnote siblings.