### PR TITLE
Fix title on root_node and a JS error

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use portal title on root_node. [mathias.leimgruber]
 
 
 1.10.0 (2018-05-25)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix JS error in arrowScrollController if there are no topLevelTabs. [mathias.leimgruber]
 - Use portal title on root_node. [mathias.leimgruber]
 
 

--- a/ftw/mobile/resources/js/navigation-button.js
+++ b/ftw/mobile/resources/js/navigation-button.js
@@ -8,12 +8,15 @@
       var storage;
       var endpoint;
       var root_url;
+      var root_title;
 
       function init(current_url, endpoint_viewname, ready_callback, startup_cachekey, ignoreExcludeFromNav){
         root_url = $("#ftw-mobile-menu-buttons").data("navrooturl");
+        root_title = $("#ftw-mobile-menu-buttons").data("portaltitle");
         var root_node = {
           url: root_url,
-          path: ''
+          path: '',
+          title: root_title
         };
         storage = {node_by_path: {'': root_node},
                    nodes_by_parent_path: {}};

--- a/ftw/mobile/resources/js/simple-buttons.js
+++ b/ftw/mobile/resources/js/simple-buttons.js
@@ -118,7 +118,10 @@
       root.off(vendorTransitionEnd.join(" "));
       $('#ftw-mobile-menu').attr('aria-hidden', 'false');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:opened');
-      arrowScrollController.selectCurrent();
+
+      if ($('.topLevelTabs').length === 1) {
+        arrowScrollController.selectCurrent();
+      }
     });
   }
 

--- a/ftw/mobile/templates/buttons_viewlet.pt
+++ b/ftw/mobile/templates/buttons_viewlet.pt
@@ -1,6 +1,7 @@
 <div id="ftw-mobile-wrapper">
     <nav id="ftw-mobile-menu-buttons"
          tal:attributes="data-navrooturl string:${view/nav_root_url};
+                         data-portaltitle string: ${view/portal_state/portal_title};
                          data-currenturl string:${view/current_url};
                          data-i18n string:${view/translation_strings}">
         <ul>


### PR DESCRIPTION
This was only a issue if `show_tabs ` is False.

Before:
<img width="555" alt="screen shot 2018-09-04 at 22 57 14" src="https://user-images.githubusercontent.com/437933/45057483-075e3e80-b096-11e8-9dd9-736921939573.png">

After:
<img width="581" alt="screen shot 2018-09-04 at 22 57 05" src="https://user-images.githubusercontent.com/437933/45057493-0c22f280-b096-11e8-899e-efb6e9faff85.png">

This PR also fixes a small JS error, which occurred after sliding in.
