### PR TITLE
Use a better selector for the script detach part (to catch only actual js).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use a better selector for the script detach part (to catch only actual js). [mathias.leimgruber]
 
 
 1.10.1 (2018-11-12)

--- a/ftw/mobile/resources/js/simple-buttons.js
+++ b/ftw/mobile/resources/js/simple-buttons.js
@@ -70,7 +70,7 @@
   // with the offcanvas wrapper to make the slide in navigation
   // working on Safari and on iOS devices
   function prepareHTML() {
-    var scripts = $("body script").not("[type='text/x-handlebars-template']").detach();
+    var scripts = $("body script[type='text/javascript'], body script:not([type])").detach();
     $("body").wrapInner(offcanvasWrapper());
     scripts.each(function(script) {
       $(script).parent().append(script);


### PR DESCRIPTION
This line of js detaches the scripts in the body tag, since we wrapp it with another element, which would trigger `load` events if binded. Thus we remove and reattach them after the wrapper element has been applied to the DOM. 

The selector was unfortunately not specific enough. A lot of integration scripts depend on a custom script type. which got removed automatically. 

This change tries to only detach actual JS script by selecting text/javascript and all script tags without a type attr, since the default there is text/javascript