### PR TITLE
Backport https://github.com/4teamwork/ftw.mobile/pull/58

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+1.7.1 (unreleased)
+-------------------
+
+- Fix JS error in arrowScrollController if there are no topLevelTabs. [mathias.leimgruber]
+- Use portal title on root_node. [mathias.leimgruber]
+
+
 1.7.0 (2017-06-02)
 ------------------
 

--- a/ftw/mobile/resources/js/navigation-button.js
+++ b/ftw/mobile/resources/js/navigation-button.js
@@ -8,12 +8,15 @@
       var storage;
       var endpoint;
       var root_url;
+      var root_title;
 
       function init(current_url, endpoint_viewname, ready_callback, startup_cachekey){
         root_url = $("#ftw-mobile-menu-buttons").data("navrooturl");
+        root_title = $("#ftw-mobile-menu-buttons").data("portaltitle");
         var root_node = {
           url: root_url,
-          path: ''
+          path: '',
+          title: root_title
         };
         storage = {node_by_path: {'': root_node},
                    nodes_by_parent_path: {}};

--- a/ftw/mobile/resources/js/simple-buttons.js
+++ b/ftw/mobile/resources/js/simple-buttons.js
@@ -118,7 +118,10 @@
       root.off(vendorTransitionEnd.join(" "));
       $('#ftw-mobile-menu').attr('aria-hidden', 'false');
       $('#ftw-mobile-menu').trigger('mobilenav:nav:opened');
-      arrowScrollController.selectCurrent();
+
+      if ($('.topLevelTabs').length === 1) {
+        arrowScrollController.selectCurrent();
+      }
     });
   }
 

--- a/ftw/mobile/templates/buttons_viewlet.pt
+++ b/ftw/mobile/templates/buttons_viewlet.pt
@@ -1,6 +1,7 @@
 <div id="ftw-mobile-wrapper">
     <nav id="ftw-mobile-menu-buttons"
          tal:attributes="data-navrooturl string:${view/nav_root_url};
+                         data-portaltitle string: ${view/portal_state/portal_title};
                          data-currenturl string:${view/current_url};
                          data-i18n string:${view/translation_strings}">
         <ul>


### PR DESCRIPTION
This pull request backports https://github.com/4teamwork/ftw.mobile/pull/58 from 1.10.1 to 1.7.x since not every project using ftw.mobile is able to upgrade to 1.10.1 because ftw.theming >= 2.0.0 is required since ftw.mobile 1.8.0.