### PR TITLE
Style mobile buttons

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Place mobile buttons next to text in default layout. [busykoala]
 
 
 2.0.0 (2019-08-13)

--- a/ftw/mobile/scss/mobile-menu-buttons.scss
+++ b/ftw/mobile/scss/mobile-menu-buttons.scss
@@ -119,7 +119,7 @@ $color-mobile-current: $color-gray-dark !default;
 .tabPane ul {
   @include list-group();
   float: left;
-  width: 100%;
+  width: calc(100% - #{$padding-horizontal});
 
   > li {
     @include clearfix();
@@ -132,14 +132,14 @@ $color-mobile-current: $color-gray-dark !default;
     > a {
       display: block;
       float: left;
-      width: calc(100% - #{$size-mobile-button});
       font-size: $font-size-medium;
       padding-right: 0;
+      width: calc(100% - #{$size-mobile-button} - #{$padding-horizontal});
       > span {
         @include hidden-structure();
       }
       &.mobileActionNav {
-        width: $size-mobile-button;
+        width: calc(#{$size-mobile-button} - #{$padding-horizontal});
       }
     }
 
@@ -150,8 +150,8 @@ $color-mobile-current: $color-gray-dark !default;
         }
 
         > a {
-          padding-left: $padding-horizontal * 2;
           background-color: $color-gray-light;
+          padding-left: $padding-horizontal;
           &.mobileActionNav {
             padding-left: $padding-horizontal;
           }
@@ -165,7 +165,7 @@ $color-mobile-current: $color-gray-dark !default;
     background-color: $color-mobile-current;
     @include auto-link-color($color-mobile-current);
     font-weight: bold;
-    width: 100%;
+    width: calc(100% - #{$padding-horizontal});
   }
 }
 


### PR DESCRIPTION
Close https://github.com/4teamwork/ftw.mobile/issues/13

I styled the mobile buttons a little, so that they appear next to the text.

![image](https://user-images.githubusercontent.com/29920936/62962675-a986ba80-bdff-11e9-9b0a-5af5a665edc5.png)
![image](https://user-images.githubusercontent.com/29920936/62962693-b3102280-bdff-11e9-9685-07a5456e64ea.png)
![image](https://user-images.githubusercontent.com/29920936/62962712-bacfc700-bdff-11e9-871b-b5cc9adea5a2.png)
