### PR TITLE
Fix JS error by not init nav menu if html structure is missing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix JS error by not init nav menu if html structure is missing. [mathias.leimgruber]
 
 
 1.10.2 (2019-05-16)

--- a/ftw/mobile/resources/js/simple-buttons.js
+++ b/ftw/mobile/resources/js/simple-buttons.js
@@ -347,6 +347,12 @@
     }
   })
   .ready(function() {
+
+    if ($('#ftw-mobile-wrapper').length === 0) {
+      // Do not anything, since ftw.mobile html structure is not available
+      return;
+    }
+
     Handlebars.registerPartial("list", $("#ftw-mobile-navigation-list-template").html());
 
     var translations = $("#ftw-mobile-menu-buttons").data('i18n');


### PR DESCRIPTION
This is a backport of #71 to the 1.10.x series